### PR TITLE
:label: Improves Event Typing

### DIFF
--- a/types/alpinejs/alpinejs-tests.ts
+++ b/types/alpinejs/alpinejs-tests.ts
@@ -648,6 +648,11 @@ import Alpine, {
         "@custom-event"(e: string) {},
         // does not require event
         "@keydown"() {},
+        // infers Event type
+        "@keyup"(e) {
+            // $ExpectType KeyboardEvent
+            e;
+        },
     }));
 
     // @ts-expect-error: does not allow incorrect event types

--- a/types/alpinejs/alpinejs-tests.ts
+++ b/types/alpinejs/alpinejs-tests.ts
@@ -632,19 +632,27 @@ import Alpine, {
     // $ExpectType void
     Alpine.bind("#my-el", () => ({
         "x-show": "true",
-        "@mouseenter"() {
-        },
-        "@mouseleave"(e: MouseEvent) {
-        },
+        "@mouseenter"() {},
+        "@mouseleave"(e: MouseEvent) {},
     }));
 
     // $ExpectType void
-    Alpine.bind(null as unknown as HTMLElement, () => ({
+    Alpine.bind(document.createElement("div") as HTMLElement, () => ({
         "x-show": "true",
-        "@mouseenter"() {
-        },
-        "@mouseleave"(e: MouseEvent) {
-        },
+        // allows typed events for x-on and @ bindings
+        "x-on:keydown"(e: KeyboardEvent) {},
+        "@mouseleave"(e: MouseEvent) {},
+        // allows higher event types
+        "@click"(e: Event) {},
+        // does not limit events on custom events
+        "@custom-event"(e: string) {},
+        // does not require event
+        "@keydown"() {},
+    }));
+
+    // @ts-expect-error: does not allow incorrect event types
+    Alpine.bind(document.createElement("div") as HTMLElement, () => ({
+        "x-on:keydown"(e: MouseEvent) {},
     }));
 
     // $ExpectType void

--- a/types/alpinejs/index.d.ts
+++ b/types/alpinejs/index.d.ts
@@ -3,7 +3,7 @@ export type ElementWithXAttributes<T extends Element = HTMLElement> = withXAttri
 export type withXAttributes<T extends Element> = T & Partial<XAttributes>;
 
 export interface XAttributes {
-    _x_virtualDirectives: Bindings;
+    _x_virtualDirectives: Bindings<{}>;
     _x_ids: Record<string, number>;
     _x_effects: Set<() => void>;
     _x_runEffects: () => void;
@@ -74,9 +74,11 @@ interface Binding {
     extract: boolean;
 }
 
-export interface Bindings {
-    [key: string]: string | ((...args: any[]) => unknown);
-}
+export type Bindings<T> = {
+    [key in keyof T]: key extends `${"x-on:" | "@"}${infer K extends keyof HTMLElementEventMap}`
+        ? string | ((e: HTMLElementEventMap[K]) => void)
+        : string | ((...args: any[]) => void);
+};
 
 export type AttrMutationCallback = (
     el: ElementWithXAttributes,
@@ -476,7 +478,14 @@ export interface Alpine {
         name: string,
         callback: (...args: A) => AlpineComponent<T>, // Needed generic to properly autotype objects
     ) => void;
-    bind: (name: string | ElementWithXAttributes, bindings: Bindings | ((...args: unknown[]) => Bindings)) => void;
+    /**
+     * Binds directives and attributes to an element
+     */
+    bind<T extends Bindings<T>>(element: HTMLElement, bindings: T | (() => T)): void;
+    /**
+     * Registers a named binding group to be exposed to `x-bind` directive expressions
+     */
+    bind<T extends Bindings<T>>(name: string, bindings: T | ((...args: unknown[]) => T)): void;
 }
 
 declare const Alpine: Alpine;


### PR DESCRIPTION
Couldn't do anything directly in DefinitelyTyped, so needed to make a PR to your fork (merging should update the DT PR)

This should be more like what you expected with the Event types.

Won't be simple to handle the expanded sets of events that elements like `HTMLVideoElement` would have...but this is 99% of events realistically.